### PR TITLE
Add-'namespace'-tag-to-dms-cluster

### DIFF
--- a/dms.tf
+++ b/dms.tf
@@ -18,6 +18,7 @@ resource "aws_dms_replication_subnet_group" "replication-subnet-group" {
     Description = "Managed by Terraform"
     Env         = "${var.environment-name}"
     Owner       = "${var.team_name}"
+    namespace   = "${var.namespace}"
   }
 }
 

--- a/example/dms.tf
+++ b/example/dms.tf
@@ -14,6 +14,7 @@ module "example_dms" {
   business-unit            = "example-bu"
   application              = "exampleapp"
   environment-name         = "development"
+  namespace                = "${var.namespace}"
   source_database_name     = "${var.source_database_name}"
   source_database_username = "${var.source_database_username}"
   source_database_password = "${var.source_database_password}"

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,9 @@ variable "business-unit" {
   default     = "mojdigital"
 }
 
+variable "namespace" {
+}
+
 variable "engine_type" {
   description = "Engine used e.g. postgres"
   default     = "postgres"


### PR DESCRIPTION
Why:
[Tag all AWS resources with namespace name#2348](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2348)